### PR TITLE
Add 429 handling to http endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nukosuke/go-zendesk
 
-go 1.19
+go 1.20
 
 require (
 	github.com/golang/mock v1.6.0

--- a/zendesk/app_test.go
+++ b/zendesk/app_test.go
@@ -32,7 +32,7 @@ func TestListAppInstallations(t *testing.T) {
 			},
 			SettingsObjects: []struct {
 				Name  string `json:"name"`
-				Value string `json:"value"`
+				Value any    `json:"value"`
 			}{
 				{
 					Name:  "setting-one",
@@ -61,7 +61,7 @@ func TestListAppInstallations(t *testing.T) {
 			},
 			SettingsObjects: []struct {
 				Name  string `json:"name"`
-				Value string `json:"value"`
+				Value any    `json:"value"`
 			}{
 				{
 					Name:  "foo",

--- a/zendesk/attachment.go
+++ b/zendesk/attachment.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sync"
 )
@@ -93,7 +92,7 @@ func (wr *writer) open() error {
 		}
 
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			wr.c <- result{
 				err: err,

--- a/zendesk/error.go
+++ b/zendesk/error.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -36,7 +35,7 @@ func (e Error) Error() string {
 
 // Body is the Body of the HTTP response
 func (e Error) Body() io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewBuffer(e.body))
+	return io.NopCloser(bytes.NewBuffer(e.body))
 }
 
 // Headers the HTTP headers returned from zendesk

--- a/zendesk/zendesk_test.go
+++ b/zendesk/zendesk_test.go
@@ -2,7 +2,7 @@ package zendesk
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -23,7 +23,7 @@ func fixture(filename string) string {
 }
 
 func readFixture(filename string) []byte {
-	bytes, err := ioutil.ReadFile(fixture(filename))
+	bytes, err := os.ReadFile(fixture(filename))
 	if err != nil {
 		fmt.Printf("Failed to read fixture. Check the path: %s", err)
 		os.Exit(1)
@@ -48,8 +48,9 @@ func newTestClient(mockAPI *httptest.Server) *Client {
 	c := &Client{
 		httpClient: http.DefaultClient,
 		credential: NewAPITokenCredential("", ""),
+		maxRetry:   1,
 	}
-	c.SetEndpointURL(mockAPI.URL)
+	_ = c.SetEndpointURL(mockAPI.URL)
 	return c
 }
 
@@ -172,7 +173,7 @@ func TestGetFailureCanReadErrorBody(t *testing.T) {
 	}
 
 	body := clientErr.Body()
-	_, err = ioutil.ReadAll(body)
+	_, err = io.ReadAll(body)
 	if err != nil {
 		t.Fatal("Client received error while reading client body")
 	}


### PR DESCRIPTION
If we receive a 429, consider sleeping (according to the Retry-After response header) before repeating the request, rather than returning an error to the caller.

The maximum sleep duration and number of retry attempts are configurable on the client.