### PR TITLE
DOPS-1643 add Linear team names

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@
 
 | Key                             | Value                          |
 |---------------------------------|--------------------------------|
-| **TEAM**                        | Team Name                      |
-| **TEAM-MANAGER-EMAIL**          | amit@nightfall.ai                     |
-| **SLACK-DEPLOY-NOTIFY-CHANNEL** | #deploy-notifications-channel  |
-| **SLACK-TEAM-CHANNEL**          | #team-slack-channel            |
-| **TEAM-LINEAR-SLUG**            | DTE                 |
+| **TEAM**                        | Detection                      |
+| **TEAM-MANAGER-EMAIL**          | amit@nightfall.ai              |
+| **SLACK-TEAM-CHANNEL**          | #team-detection                |
+| **TEAM-LINEAR-SLUG**            | DTE                            |
 
 [![Actions Status](https://github.com/nukosuke/go-zendesk/workflows/CI/badge.svg)](https://github.com/nukosuke/go-zendesk/actions)
 [![Build status](https://ci.appveyor.com/api/projects/status/ce4p1mswjkdftv6o/branch/master?svg=true)](https://ci.appveyor.com/project/nukosuke/go-zendesk/branch/master)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
 # go-zendesk
+
+## Service Metadata
+
+| Key                             | Value                          |
+|---------------------------------|--------------------------------|
+| **TEAM**                        | Team Name                      |
+| **TEAM-MANAGER-EMAIL**          | amit@nightfall.ai                     |
+| **SLACK-DEPLOY-NOTIFY-CHANNEL** | #deploy-notifications-channel  |
+| **SLACK-TEAM-CHANNEL**          | #team-slack-channel            |
+| **TEAM-LINEAR-SLUG**            | DTE                 |
+
 [![Actions Status](https://github.com/nukosuke/go-zendesk/workflows/CI/badge.svg)](https://github.com/nukosuke/go-zendesk/actions)
 [![Build status](https://ci.appveyor.com/api/projects/status/ce4p1mswjkdftv6o/branch/master?svg=true)](https://ci.appveyor.com/project/nukosuke/go-zendesk/branch/master)
 [![Coverage Status](https://coveralls.io/repos/github/nukosuke/go-zendesk/badge.svg?branch=master)](https://coveralls.io/github/nukosuke/go-zendesk?branch=master)


### PR DESCRIPTION
Updates README.md metadata table from repo_owners.csv.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds ownership/contact metadata to `README.md`; no runtime or API behavior is affected.
> 
> **Overview**
> Adds a **Service Metadata** section to `README.md`, documenting team ownership info (team name, manager email, Slack channel) and the team’s Linear slug (`TEAM-LINEAR-SLUG`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cfa3faefda51b789019f307ca0ce7d508b92e22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->